### PR TITLE
Remove is:open from GitHub search query

### DIFF
--- a/search.php
+++ b/search.php
@@ -52,7 +52,7 @@ else if ($wiki) {
 
 // code and issues
 else if ($github) {
-	$url = "https://github.com/search?q=$q+is%3Aopen";
+	$url = "https://github.com/search?q=$q";
 	foreach ($orgs as $org) { $url .= "+user%3A$org"; }
 	$url .= '&ref=simplesearch&type=Code';
 }


### PR DESCRIPTION
`is:open` is only useful when searching issues.

When searching code results for e.g. `scijava`, the `is:open`  would be considered a search term, and lead to the first result being highlighted 'isOpenJDK'.